### PR TITLE
Fix: added isBroswer check to isWindows and isChromiumBased function

### DIFF
--- a/src/helpers/browsers.ts
+++ b/src/helpers/browsers.ts
@@ -1,10 +1,10 @@
-import { isRunningOnClientSide } from './is-running-on-client-side';
+import { isRunningOnClientSide } from "./is-running-on-client-side";
 
 export function isFF(): boolean {
 	if (!isRunningOnClientSide) {
 		return false;
 	}
-	return window.navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+	return window.navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
 }
 
 export function isIOS(): boolean {
@@ -24,21 +24,25 @@ export function isChrome(): boolean {
 
 // Determine whether the browser is running on windows.
 export function isWindows(): boolean {
-	// more accurate if available
-	if (
-		navigator?.userAgentData?.platform
-	) {
-		return navigator.userAgentData.platform === 'Windows';
+	if (!isRunningOnClientSide) {
+		return false;
 	}
-	return navigator.userAgent.toLowerCase().indexOf('win') >= 0;
+	// more accurate if available
+	if (navigator?.userAgentData?.platform) {
+		return navigator.userAgentData.platform === "Windows";
+	}
+	return navigator.userAgent.toLowerCase().indexOf("win") >= 0;
 }
 
 // Determine whether the browser is Chromium based.
 export function isChromiumBased(): boolean {
-	if (!navigator.userAgentData) { return false; }
-	return navigator.userAgentData.brands.some(
-		(brand: UADataBrand) => {
-			return brand.brand.includes('Chromium');
-		}
-	);
+	if (!isRunningOnClientSide) {
+		return false;
+	}
+	if (!navigator.userAgentData) {
+		return false;
+	}
+	return navigator.userAgentData.brands.some((brand: UADataBrand) => {
+		return brand.brand.includes("Chromium");
+	});
 }


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

**Overview of change:**
This will fix the navigator not defined error when using this charting library with nextjs 13

![image](https://github.com/felipecsl/lightweight-charts/assets/63933740/4d053306-3d7a-4ab6-ba7d-cb907ee76750)


